### PR TITLE
bump langmodels version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Flask==1.1.1
 PyYAML==5.1.2
-giganticode-langmodels==0.0.1a0
+giganticode-langmodels==0.0.1a1


### PR DESCRIPTION
In the previous version, `TrainedModel` class was not thread-safe. Calling simultaneously its method from multiple threads (e.g. when doing multiple autocompletion request from the VSC extension one shortly after another) could lead to unpredictable results