### PR TITLE
bump langmodels lib version and adjust API accordingly

### DIFF
--- a/controller/entropy_controller.py
+++ b/controller/entropy_controller.py
@@ -42,7 +42,7 @@ class EntropyController:
         metadata['time_model_loading'] = stop_watch.elapsed() * 1000
 
         stop_watch.start()
-        model.feed_text(content)
+        model.feed_text(content, extension='java')
         metadata['time_feed'] = stop_watch.elapsed() * 1000
 
         stop_watch.start()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Flask==1.1.1
 PyYAML==5.1.2
-giganticode-langmodels==0.0.1a0
+giganticode-langmodels==0.0.1a2


### PR DESCRIPTION
In the previous version, TrainedModel class was not thread-safe. Calling simultaneously its method from multiple threads (e.g. when doing multiple autocompletion request from the VSC extension one shortly after another; when loading LMs from the repository) could lead to unpredictable results