### PR TITLE
Fix imports in controller

### DIFF
--- a/controller/entropy_controller.py
+++ b/controller/entropy_controller.py
@@ -5,14 +5,14 @@ from typing import List
 from flask import json, jsonify
 
 from dataprep.tokens.containers import StringLiteral, SplitContainer
-from evaluation import TokenTypeSubset
+from langmodels.evaluation import TokenTypeSubset
 from langmodels.evaluation.evaluation import evaluate_model_on_string
 from langmodels.evaluation.metrics import EvaluationScenario
 from langmodels.model import TrainedModel
 
 from controller.util import check_or_create
 from util.entropyresult import EntropyResult, EntropyLine, Token
-from .stopwatch import StopWatch
+from controller.stopwatch import StopWatch
 
 
 class EntropyController:


### PR DESCRIPTION
Otherwise server breaks on a request from the webtool (at least on on Python 3.7) with:
```
Traceback (most recent call last):
  File "~/gigacode/lm-powered-backend/webservice.py", line 8, in <module>
    from controller.entropy_controller import EntropyController
  File "~/gigacode/lm-powered-backend/controller/entropy_controller.py", line 8, in <module>
    from evaluation import TokenTypeSubset
ModuleNotFoundError: No module named 'evaluation'
```